### PR TITLE
Added support for publishedEndpointUrl attribute of jaxws:endpoint

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfServiceTest.java
+++ b/deployment/src/test/java/io/quarkiverse/cxf/deployment/test/CxfServiceTest.java
@@ -50,6 +50,11 @@ public class CxfServiceTest {
                 .evaluate(doc);
         Assertions.assertEquals("xs:string", val);
 
+        val = xpath
+                .compile(
+                        "/definitions/service/port/address/@location")
+                .evaluate(doc);
+        Assertions.assertEquals("https://io.quarkus-cxf.com/fruit", val);
     }
 
     @Test

--- a/deployment/src/test/resources/application-cxf-server-test.properties
+++ b/deployment/src/test/resources/application-cxf-server-test.properties
@@ -1,1 +1,2 @@
 quarkus.cxf.endpoint."/fruit".implementor=io.quarkiverse.cxf.deployment.test.FruitWebServiceImpl
+quarkus.cxf.endpoint."/fruit".published-endpoint-url=https://io.quarkus-cxf.com/fruit

--- a/runtime/src/main/java/io/quarkiverse/cxf/CXFQuarkusServlet.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/CXFQuarkusServlet.java
@@ -95,6 +95,9 @@ public class CXFQuarkusServlet extends CXFNonSpringServlet {
                 if (servletInfo.getSOAPBinding() != null) {
                     factory.setBindingId(servletInfo.getSOAPBinding());
                 }
+                if (servletInfo.getEndpointUrl() != null) {
+                    factory.setPublishedEndpointUrl(servletInfo.getEndpointUrl());
+                }
 
                 Server server = factory.create();
                 for (String className : servletInfo.getInFaultInterceptors()) {

--- a/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/CXFRecorder.java
@@ -91,7 +91,8 @@ public class CXFRecorder {
                             sei,
                             cxfEndPointConfig.wsdlPath.orElse(null),
                             soapBinding,
-                            wrapperClassNames);
+                            wrapperClassNames,
+                            cxfEndPointConfig.publishedEndpointUrl.orElse(null));
                     if (cxfEndPointConfig.inInterceptors.isPresent()) {
                         cfg.getInInterceptors().addAll(cxfEndPointConfig.inInterceptors.get());
                     }

--- a/runtime/src/main/java/io/quarkiverse/cxf/CXFServletInfo.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/CXFServletInfo.java
@@ -23,11 +23,12 @@ public class CXFServletInfo {
     private String wsdlPath;
     private String soapBinding;
     private List<String> wrapperClassNames;
+    private String endpointUrl;
 
     private static final Logger LOGGER = Logger.getLogger(CXFServletInfo.class);
 
     public CXFServletInfo(String path, String className, String sei, String wsdlPath, String soapBinding,
-            List<String> wrapperClassNames) {
+            List<String> wrapperClassNames, String endpointUrl) {
         super();
         LOGGER.warn("new CXFServletInfo");
         this.path = path;
@@ -41,6 +42,7 @@ public class CXFServletInfo {
         this.wsdlPath = wsdlPath;
         this.soapBinding = soapBinding;
         this.wrapperClassNames = wrapperClassNames;
+        this.endpointUrl = endpointUrl;
     }
 
     public String getClassName() {
@@ -85,6 +87,14 @@ public class CXFServletInfo {
 
     public List<String> getWrapperClassNames() {
         return wrapperClassNames;
+    }
+
+    public String getEndpointUrl() {
+        return endpointUrl;
+    }
+
+    public void setEndpointUrl(String endpointUrl) {
+        this.endpointUrl = endpointUrl;
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/cxf/CxfEndpointConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/cxf/CxfEndpointConfig.java
@@ -28,6 +28,12 @@ public class CxfEndpointConfig {
     public Optional<String> clientEndpointUrl;
 
     /**
+     * The server endpoint url
+     */
+    @ConfigItem
+    public Optional<String> publishedEndpointUrl;
+
+    /**
      * The client interface
      */
     @ConfigItem


### PR DESCRIPTION
Hello. First of all thanks for your efforts on making quarkus with soap a reality.
So...
I've added support for a new atribute of CXF called **publishedEndpointUrl**.
It is responsible for setting the soapAddress of WSDL and this is well described in the docs:

> The URL that is placed in the address element of the wsdl when the wsdl is retrieved. If not specified, the address listed above is used. This parameter allows setting the "public" URL that may not be the same as the URL the service is deployed on. (for example, the service is behind a proxy of some sort).

http://cxf.apache.org/docs/jax-ws-configuration.html

Please consider this pull request as it is essencial for my project as well I think it would be for many others.
