### PR TITLE
avoid NPE if no CXF web services are present

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -1341,18 +1341,22 @@ class QuarkusCxfProcessor {
             CxfConfig cxfConfig) {
         String path = null;
 
-        RuntimeValue<CXFServletInfos> infos = recorder.createInfos();
-        for (CxfWebServiceBuildItem cxfWebService : cxfWebServices) {
-            recorder.registerCXFServlet(infos, cxfWebService.getPath(), cxfWebService.getSei(),
-                    cxfConfig, cxfWebService.getSoapBinding(), cxfWebService.getClassNames(), cxfWebService.getImplementor());
-            if (path == null) {
-                path = cxfWebService.getPath();
-                recorder.setPath(infos, path);
+        if (!cxfWebServices.isEmpty()) {
+            RuntimeValue<CXFServletInfos> infos = recorder.createInfos();
+            for (CxfWebServiceBuildItem cxfWebService : cxfWebServices) {
+                recorder.registerCXFServlet(infos, cxfWebService.getPath(), cxfWebService.getSei(),
+                        cxfConfig, cxfWebService.getSoapBinding(), cxfWebService.getClassNames(),
+                        cxfWebService.getImplementor());
+                if (path == null) {
+                    path = cxfWebService.getPath();
+                    recorder.setPath(infos, path);
+                }
+            }
+            Handler<RoutingContext> handler = recorder.initServer(infos);
+            if (path != null) {
+                routes.produce(new RouteBuildItem(getMappingPath(path), handler, HandlerType.BLOCKING));
             }
         }
-        Handler<RoutingContext> handler = recorder.initServer(infos);
-
-        routes.produce(new RouteBuildItem(getMappingPath(path), handler, HandlerType.BLOCKING));
     }
 
     @BuildStep


### PR DESCRIPTION
This fixes the following error:
`[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:1.10.5.Final:build (default) on project LambdaQuarkus: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]         [error]: Build step io.quarkiverse.cxf.deployment.QuarkusCxfProcessor#startRoute threw an exception: java.lang.NullPointerException
[ERROR]         at io.quarkiverse.cxf.deployment.QuarkusCxfProcessor.getMappingPath(QuarkusCxfProcessor.java:2046)
[ERROR]         at io.quarkiverse.cxf.deployment.QuarkusCxfProcessor.startRoute(QuarkusCxfProcessor.java:1355)`