### PR TITLE
test WSDL-generated SEI

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -255,11 +255,6 @@ class QuarkusCxfProcessor {
                     } else {
                         wsName = implementor;
                     }
-                    AnnotationInstance webserviceClient = wsClass.classAnnotation(WEBSERVICE_CLIENT);
-                    if (webserviceClient != null) {
-                        wsName = webserviceClient.value("name").asString();
-                        wsNamespace = webserviceClient.value("targetNamespace").asString();
-                    }
                     additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(implementor));
                     AnnotationInstance bindingType = wsClass.classAnnotation(BINDING_TYPE_ANNOTATION);
                     if (bindingType != null) {

--- a/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -241,6 +241,12 @@ class QuarkusCxfProcessor {
                 generateCxfClientProducer(generatedBeans, seiClientproducerClassName, sei);
                 unremovableBeans.produce(new UnremovableBeanBuildItem(
                         new UnremovableBeanBuildItem.BeanClassNameExclusion(seiClientproducerClassName)));
+
+                AnnotationInstance webserviceClient = findWebServiceClientAnnotation(index, wsClassInfo.name());
+                if (webserviceClient != null) {
+                    wsName = webserviceClient.value("name").asString();
+                    wsNamespace = webserviceClient.value("targetNamespace").asString();
+                }
             } else {
                 for (ClassInfo wsClass : implementors) {
                     implementor = wsClass.name().toString();
@@ -297,6 +303,21 @@ class QuarkusCxfProcessor {
         for (ClassInfo subclass : index.getAllKnownImplementors(DATABINDING)) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, subclass.name().toString()));
         }
+    }
+
+    private AnnotationInstance findWebServiceClientAnnotation(IndexView index, DotName seiName) {
+        Collection<AnnotationInstance> annotations = index.getAnnotations(WEBSERVICE_CLIENT);
+        for (AnnotationInstance annotation : annotations) {
+            ClassInfo targetClass = annotation.target().asClass();
+
+            for (MethodInfo method : targetClass.methods()) {
+                if (method.returnType().name().equals(seiName)) {
+                    return annotation;
+                }
+            }
+        }
+
+        return null;
     }
 
     @BuildStep

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -86,9 +86,6 @@
                                 <wsdlOption>
                                     <wsdl>${basedir}/src/main/resources/wsdl/calculator.wsdl</wsdl>
                                     <wsdlLocation>classpath:wsdl/calculator.wsdl</wsdlLocation>
-                                    <bindingFiles>
-                                        <bindingFile>${basedir}/src/main/resources/wsdl/calculator_binding.xml</bindingFile>
-                                    </bindingFiles>
                                 </wsdlOption>
                                 <wsdlOption>
                                     <wsdl>${basedir}/src/main/resources/wsdl/alt_calculator.wsdl</wsdl>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -50,6 +50,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http-jetty</artifactId>
+            <version>${cxf.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -63,6 +69,29 @@
                         <goals>
                             <goal>build</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-codegen-plugin</artifactId>
+                <version>${cxf.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>wsdl2java</goal>
+                        </goals>
+                        <configuration>
+                            <wsdlOptions>
+                                <wsdlOption>
+                                    <wsdl>${basedir}/src/main/resources/wsdl/calculator.wsdl</wsdl>
+                                    <wsdlLocation>classpath:wsdl/calculator.wsdl</wsdlLocation>
+                                    <bindingFiles>
+                                        <bindingFile>${basedir}/src/main/resources/wsdl/calculator_binding.xml</bindingFile>
+                                    </bindingFiles>
+                                </wsdlOption>
+                            </wsdlOptions>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -90,6 +90,10 @@
                                         <bindingFile>${basedir}/src/main/resources/wsdl/calculator_binding.xml</bindingFile>
                                     </bindingFiles>
                                 </wsdlOption>
+                                <wsdlOption>
+                                    <wsdl>${basedir}/src/main/resources/wsdl/alt_calculator.wsdl</wsdl>
+                                    <wsdlLocation>classpath:wsdl/alt_calculator.wsdl</wsdlLocation>
+                                </wsdlOption>
                             </wsdlOptions>
                         </configuration>
                     </execution>

--- a/integration-tests/src/main/java/io/quarkiverse/it/cxf/ClientFacadeResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/it/cxf/ClientFacadeResource.java
@@ -7,14 +7,14 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.tempuri.Calculator;
+import org.tempuri.CalculatorSoap;
 import org.tempuri.alt.AltCalculatorSoap;
 
 @Path("/rest/clientfacade")
 public class ClientFacadeResource {
 
     @Inject
-    Calculator calculatorWS;
+    CalculatorSoap calculatorWS;
 
     @Inject
     AltCalculatorSoap altCalculatorWS;

--- a/integration-tests/src/main/java/io/quarkiverse/it/cxf/ClientFacadeResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/it/cxf/ClientFacadeResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.tempuri.Calculator;
+import org.tempuri.alt.AltCalculatorSoap;
 
 @Path("/rest/clientfacade")
 public class ClientFacadeResource {
@@ -15,9 +16,20 @@ public class ClientFacadeResource {
     @Inject
     Calculator calculatorWS;
 
+    @Inject
+    AltCalculatorSoap altCalculatorWS;
+
     @GET
+    @Path("/multiply")
     @Produces(MediaType.TEXT_PLAIN)
     public int multiply(@QueryParam("a") int a, @QueryParam("b") int b) {
         return calculatorWS.multiply(a, b);
+    }
+
+    @GET
+    @Path("/add")
+    @Produces(MediaType.TEXT_PLAIN)
+    public int add(@QueryParam("a") int a, @QueryParam("b") int b) {
+        return altCalculatorWS.add(a, b);
     }
 }

--- a/integration-tests/src/main/java/io/quarkiverse/it/cxf/ClientFacadeResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/it/cxf/ClientFacadeResource.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.it.cxf;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.tempuri.Calculator;
+
+@Path("/rest/clientfacade")
+public class ClientFacadeResource {
+
+    @Inject
+    Calculator calculatorWS;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public int multiply(@QueryParam("a") int a, @QueryParam("b") int b) {
+        return calculatorWS.multiply(a, b);
+    }
+}

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.cxf.endpoint."/greeting".published-endpoint-url=https://io.quarkus-cxf.c
 
 quarkus.cxf.endpoint."mockCalculator".wsdl=http://localhost:9000/mockCalculator?wsdl
 quarkus.cxf.endpoint."mockCalculator".client-endpoint-url=http://localhost:9000
-quarkus.cxf.endpoint."mockCalculator".service-interface=org.tempuri.Calculator
+quarkus.cxf.endpoint."mockCalculator".service-interface=org.tempuri.CalculatorSoap
 quarkus.cxf.endpoint."mockCalculator".endpoint-namespace=http://tempuri.org/
 quarkus.cxf.endpoint."mockCalculator".endpoint-name=CalculatorSoap
 

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -3,3 +3,9 @@ quarkus.cxf.endpoint."/greeting".implementor=io.quarkiverse.it.cxf.GreetingWebSe
 quarkus.cxf.endpoint."/foo".client-endpoint-url=http://localhost:8081/soap/greeting
 quarkus.cxf.endpoint."/foo".service-interface=io.quarkiverse.it.cxf.GreetingClientWebService
 quarkus.cxf.endpoint."/greeting".published-endpoint-url=https://io.quarkus-cxf.com/test
+
+quarkus.cxf.endpoint."mockCalculator".wsdl=http://localhost:9000/mockCalculator?wsdl
+quarkus.cxf.endpoint."mockCalculator".client-endpoint-url=http://localhost:9000
+quarkus.cxf.endpoint."mockCalculator".service-interface=org.tempuri.Calculator
+quarkus.cxf.endpoint."mockCalculator".endpoint-namespace=http://tempuri.org/
+quarkus.cxf.endpoint."mockCalculator".endpoint-name=CalculatorSoap

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -9,3 +9,9 @@ quarkus.cxf.endpoint."mockCalculator".client-endpoint-url=http://localhost:9000
 quarkus.cxf.endpoint."mockCalculator".service-interface=org.tempuri.Calculator
 quarkus.cxf.endpoint."mockCalculator".endpoint-namespace=http://tempuri.org/
 quarkus.cxf.endpoint."mockCalculator".endpoint-name=CalculatorSoap
+
+quarkus.cxf.endpoint."mockAltCalculator".wsdl=http://localhost:9000/mockAltCalculator?wsdl
+quarkus.cxf.endpoint."mockAltCalculator".client-endpoint-url=http://localhost:9000
+quarkus.cxf.endpoint."mockAltCalculator".service-interface=org.tempuri.alt.AltCalculatorSoap
+quarkus.cxf.endpoint."mockAltCalculator".endpoint-namespace=http://alt.tempuri.org/
+quarkus.cxf.endpoint."mockAltCalculator".endpoint-name=AltCalculatorSoap

--- a/integration-tests/src/main/resources/wsdl/alt_calculator.wsdl
+++ b/integration-tests/src/main/resources/wsdl/alt_calculator.wsdl
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- modified version of calculator.wsdl -->
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://alt.tempuri.org/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://alt.tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://alt.tempuri.org/">
+      <s:element name="Add">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" nillable="true" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="0" nillable="true" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="AddResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" nillable="true" maxOccurs="1" name="AddResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Subtract">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="SubtractResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="SubtractResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Multiply">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="MultiplyResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="MultiplyResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Divide">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="DivideResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="DivideResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="AddSoapIn">
+    <wsdl:part name="parameters" element="tns:Add"/>
+  </wsdl:message>
+  <wsdl:message name="AddSoapOut">
+    <wsdl:part name="parameters" element="tns:AddResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapIn">
+    <wsdl:part name="parameters" element="tns:Subtract"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapOut">
+    <wsdl:part name="parameters" element="tns:SubtractResponse"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapIn">
+    <wsdl:part name="parameters" element="tns:Multiply"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapOut">
+    <wsdl:part name="parameters" element="tns:MultiplyResponse"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapIn">
+    <wsdl:part name="parameters" element="tns:Divide"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapOut">
+    <wsdl:part name="parameters" element="tns:DivideResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="AltCalculatorSoap">
+    <wsdl:operation name="Add">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Adds two integers. Modified version of the original Add that forces usage of JAXBElement in Java.</wsdl:documentation>
+      <wsdl:input message="tns:AddSoapIn"/>
+      <wsdl:output message="tns:AddSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <wsdl:input message="tns:SubtractSoapIn"/>
+      <wsdl:output message="tns:SubtractSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <wsdl:input message="tns:MultiplySoapIn"/>
+      <wsdl:output message="tns:MultiplySoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <wsdl:input message="tns:DivideSoapIn"/>
+      <wsdl:output message="tns:DivideSoapOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="CalculatorSoap" type="tns:AltCalculatorSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap:operation soapAction="http://alt.tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap:operation soapAction="http://alt.tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap:operation soapAction="http://alt.tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap:operation soapAction="http://alt.tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="CalculatorSoap12" type="tns:AltCalculatorSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap12:operation soapAction="http://alt.tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap12:operation soapAction="http://alt.tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap12:operation soapAction="http://alt.tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap12:operation soapAction="http://alt.tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="AltCalculator">
+    <wsdl:port name="CalculatorSoap" binding="tns:CalculatorSoap">
+      <soap:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+    <wsdl:port name="CalculatorSoap12" binding="tns:CalculatorSoap12">
+      <soap12:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/integration-tests/src/main/resources/wsdl/calculator.wsdl
+++ b/integration-tests/src/main/resources/wsdl/calculator.wsdl
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- taken verbatim from http://www.dneonline.com/calculator.asmx?wsdl -->
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://tempuri.org/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+      <s:element name="Add">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="AddResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="AddResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Subtract">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="SubtractResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="SubtractResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Multiply">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="MultiplyResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="MultiplyResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="Divide">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int"/>
+            <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="DivideResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="1" maxOccurs="1" name="DivideResult" type="s:int"/>
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="AddSoapIn">
+    <wsdl:part name="parameters" element="tns:Add"/>
+  </wsdl:message>
+  <wsdl:message name="AddSoapOut">
+    <wsdl:part name="parameters" element="tns:AddResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapIn">
+    <wsdl:part name="parameters" element="tns:Subtract"/>
+  </wsdl:message>
+  <wsdl:message name="SubtractSoapOut">
+    <wsdl:part name="parameters" element="tns:SubtractResponse"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapIn">
+    <wsdl:part name="parameters" element="tns:Multiply"/>
+  </wsdl:message>
+  <wsdl:message name="MultiplySoapOut">
+    <wsdl:part name="parameters" element="tns:MultiplyResponse"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapIn">
+    <wsdl:part name="parameters" element="tns:Divide"/>
+  </wsdl:message>
+  <wsdl:message name="DivideSoapOut">
+    <wsdl:part name="parameters" element="tns:DivideResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CalculatorSoap">
+    <wsdl:operation name="Add">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Adds two integers. This is a test WebService. ©DNE Online</wsdl:documentation>
+      <wsdl:input message="tns:AddSoapIn"/>
+      <wsdl:output message="tns:AddSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <wsdl:input message="tns:SubtractSoapIn"/>
+      <wsdl:output message="tns:SubtractSoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <wsdl:input message="tns:MultiplySoapIn"/>
+      <wsdl:output message="tns:MultiplySoapOut"/>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <wsdl:input message="tns:DivideSoapIn"/>
+      <wsdl:output message="tns:DivideSoapOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="CalculatorSoap" type="tns:CalculatorSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap:operation soapAction="http://tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap:operation soapAction="http://tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap:operation soapAction="http://tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap:operation soapAction="http://tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="CalculatorSoap12" type="tns:CalculatorSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Add">
+      <soap12:operation soapAction="http://tempuri.org/Add" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Subtract">
+      <soap12:operation soapAction="http://tempuri.org/Subtract" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Multiply">
+      <soap12:operation soapAction="http://tempuri.org/Multiply" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Divide">
+      <soap12:operation soapAction="http://tempuri.org/Divide" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Calculator">
+    <wsdl:port name="CalculatorSoap" binding="tns:CalculatorSoap">
+      <soap:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+    <wsdl:port name="CalculatorSoap12" binding="tns:CalculatorSoap12">
+      <soap12:address location="http://www.dneonline.com/calculator.asmx"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/integration-tests/src/main/resources/wsdl/calculator_binding.xml
+++ b/integration-tests/src/main/resources/wsdl/calculator_binding.xml
@@ -1,0 +1,7 @@
+<bindings xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns="http://java.sun.com/xml/ns/jaxws">
+    <bindings node="wsdl:definitions/wsdl:portType[@name='CalculatorSoap']">
+        <class name="Calculator"/>
+    </bindings>
+</bindings>

--- a/integration-tests/src/main/resources/wsdl/calculator_binding.xml
+++ b/integration-tests/src/main/resources/wsdl/calculator_binding.xml
@@ -1,7 +1,0 @@
-<bindings xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-    xmlns="http://java.sun.com/xml/ns/jaxws">
-    <bindings node="wsdl:definitions/wsdl:portType[@name='CalculatorSoap']">
-        <class name="Calculator"/>
-    </bindings>
-</bindings>

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.it.cxf;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import javax.xml.ws.Endpoint;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.transport.http_jetty.JettyHTTPServerEngineFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.it.cxf.mock.CalculatorMockImpl;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class ClientFacadeResourceTest {
+
+    private static Endpoint ENDPOINT;
+
+    @BeforeAll
+    public static void setUpClass() throws GeneralSecurityException, IOException {
+        Bus defaultBus = BusFactory.getDefaultBus();
+        new JettyHTTPServerEngineFactory(defaultBus).createJettyHTTPServerEngine(9000, "http");
+
+        String address = "http://localhost:9000/mockCalculator";
+        CalculatorMockImpl implementor = new CalculatorMockImpl();
+
+        ENDPOINT = Endpoint.publish(address, implementor);
+    }
+
+    @AfterAll
+    public static void tearDownClass() {
+        if (ENDPOINT != null) {
+            ENDPOINT.stop();
+        }
+    }
+
+    @Test
+    public void testMultiply() {
+        given().param("a", 13).param("b", 17)
+                .when().get("/rest/clientfacade")
+                .then().statusCode(200).body(is("221"));
+    }
+
+}

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.CoreMatchers.is;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.ws.Endpoint;
 
@@ -15,13 +17,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.it.cxf.mock.AltCalculatorMockImpl;
 import io.quarkiverse.it.cxf.mock.CalculatorMockImpl;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class ClientFacadeResourceTest {
 
-    private static Endpoint ENDPOINT;
+    private static final List<Endpoint> ENDPOINTS = new ArrayList<>();
 
     @BeforeAll
     public static void setUpClass() throws GeneralSecurityException, IOException {
@@ -31,21 +34,31 @@ class ClientFacadeResourceTest {
         String address = "http://localhost:9000/mockCalculator";
         CalculatorMockImpl implementor = new CalculatorMockImpl();
 
-        ENDPOINT = Endpoint.publish(address, implementor);
+        String altAddress = "http://localhost:9000/mockAltCalculator";
+        AltCalculatorMockImpl altImplementor = new AltCalculatorMockImpl();
+
+        ENDPOINTS.add(Endpoint.publish(address, implementor));
+        ENDPOINTS.add(Endpoint.publish(altAddress, altImplementor));
     }
 
     @AfterAll
     public static void tearDownClass() {
-        if (ENDPOINT != null) {
-            ENDPOINT.stop();
-        }
+        ENDPOINTS.forEach(
+                Endpoint::stop);
     }
 
     @Test
     public void testMultiply() {
         given().param("a", 13).param("b", 17)
-                .when().get("/rest/clientfacade")
+                .when().get("/rest/clientfacade/multiply")
                 .then().statusCode(200).body(is("221"));
+    }
+
+    @Test
+    public void testAdd() {
+        given().param("a", 19).param("b", 23)
+                .when().get("/rest/clientfacade/add")
+                .then().statusCode(200).body(is("42"));
     }
 
 }

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTestIT.java
@@ -1,51 +1,8 @@
 package io.quarkiverse.it.cxf;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-
-import javax.xml.ws.Endpoint;
-
-import org.apache.cxf.Bus;
-import org.apache.cxf.BusFactory;
-import org.apache.cxf.transport.http_jetty.JettyHTTPServerEngineFactory;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import io.quarkiverse.it.cxf.mock.CalculatorMockImpl;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-class ClientFacadeResourceTestIT {
-
-    private static Endpoint ENDPOINT;
-
-    @BeforeAll
-    public static void setUpClass() throws GeneralSecurityException, IOException {
-        Bus defaultBus = BusFactory.getDefaultBus();
-        new JettyHTTPServerEngineFactory(defaultBus).createJettyHTTPServerEngine(9000, "http");
-
-        String address = "http://localhost:9000/mockCalculator";
-        CalculatorMockImpl implementor = new CalculatorMockImpl();
-
-        ENDPOINT = Endpoint.publish(address, implementor);
-    }
-
-    @AfterAll
-    public static void tearDownClass() {
-        if (ENDPOINT != null) {
-            ENDPOINT.stop();
-        }
-    }
-
-    @Test
-    public void testMultiply() {
-        given().param("a", 13).param("b", 17)
-                .when().get("/rest/clientfacade")
-                .then().statusCode(200).body(is("221"));
-    }
+class ClientFacadeResourceTestIT extends ClientFacadeResourceTest {
 
 }

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTestIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/ClientFacadeResourceTestIT.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.it.cxf;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import javax.xml.ws.Endpoint;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.transport.http_jetty.JettyHTTPServerEngineFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.it.cxf.mock.CalculatorMockImpl;
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+class ClientFacadeResourceTestIT {
+
+    private static Endpoint ENDPOINT;
+
+    @BeforeAll
+    public static void setUpClass() throws GeneralSecurityException, IOException {
+        Bus defaultBus = BusFactory.getDefaultBus();
+        new JettyHTTPServerEngineFactory(defaultBus).createJettyHTTPServerEngine(9000, "http");
+
+        String address = "http://localhost:9000/mockCalculator";
+        CalculatorMockImpl implementor = new CalculatorMockImpl();
+
+        ENDPOINT = Endpoint.publish(address, implementor);
+    }
+
+    @AfterAll
+    public static void tearDownClass() {
+        if (ENDPOINT != null) {
+            ENDPOINT.stop();
+        }
+    }
+
+    @Test
+    public void testMultiply() {
+        given().param("a", 13).param("b", 17)
+                .when().get("/rest/clientfacade")
+                .then().statusCode(200).body(is("221"));
+    }
+
+}

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/mock/AltCalculatorMockImpl.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/mock/AltCalculatorMockImpl.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.it.cxf.mock;
+
+import javax.jws.WebService;
+
+import org.tempuri.alt.AltCalculatorSoap;
+
+/**
+ * Mock implementation of {@link AltCalculatorSoap}. We
+ * do not implement the interface because that would break the injection of
+ * clients for that interface. Instead we use the
+ * {@link WebService#endpointInterface} attribute.
+ */
+@WebService(targetNamespace = "http://alt.tempuri.org/", endpointInterface = "org.tempuri.alt.AltCalculatorSoap", serviceName = "AltCalculator", portName = "AltCalculatorSoap")
+public class AltCalculatorMockImpl {
+
+    public int subtract(int intA, int intB) {
+        return intA - intB;
+    }
+
+    public int divide(int intA, int intB) {
+        return intA / intB;
+    }
+
+    public Integer add(Integer intA, Integer intB) {
+        return intA + intB;
+    }
+
+    public int multiply(int intA, int intB) {
+        return intA * intB;
+    }
+
+}

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/mock/CalculatorMockImpl.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/mock/CalculatorMockImpl.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.it.cxf.mock;
+
+import javax.jws.WebService;
+
+/**
+ * Mock implementation of {@link org.tempuri.CalculatorSoap CalculatorSoap}. We
+ * do not implement the interface because that would break the injection of
+ * clients for that interface. Instead we use the
+ * {@link WebService#endpointInterface} attribute.
+ */
+@WebService(targetNamespace = "http://tempuri.org/", endpointInterface = "org.tempuri.Calculator", serviceName = "Calculator", portName = "CalculatorSoap")
+public class CalculatorMockImpl {
+
+    public int subtract(int intA, int intB) {
+        return intA - intB;
+    }
+
+    public int divide(int intA, int intB) {
+        return intA / intB;
+    }
+
+    public int add(int intA, int intB) {
+        return intA + intB;
+    }
+
+    public int multiply(int intA, int intB) {
+        return intA * intB;
+    }
+
+}

--- a/integration-tests/src/test/java/io/quarkiverse/it/cxf/mock/CalculatorMockImpl.java
+++ b/integration-tests/src/test/java/io/quarkiverse/it/cxf/mock/CalculatorMockImpl.java
@@ -8,7 +8,7 @@ import javax.jws.WebService;
  * clients for that interface. Instead we use the
  * {@link WebService#endpointInterface} attribute.
  */
-@WebService(targetNamespace = "http://tempuri.org/", endpointInterface = "org.tempuri.Calculator", serviceName = "Calculator", portName = "CalculatorSoap")
+@WebService(targetNamespace = "http://tempuri.org/", endpointInterface = "org.tempuri.CalculatorSoap", serviceName = "Calculator", portName = "CalculatorSoap")
 public class CalculatorMockImpl {
 
     public int subtract(int intA, int intB) {


### PR DESCRIPTION
As discussed in #85, here's an implementation of a test using a SEI generated from a WSDL. Some notes:
- The WSDL used was taken from an official SoapUI tutorial so I just assumed it was both sufficiently representative and not encumbered by any confidentiality issues. In any case, no calls are being made to the original service, either to get the WSDL or to invoke the service.
- ~~This changeset includes a workaround for #85 (using a bindings file) so it will pass the tests for now. This bindings files should eventually be removed as a way to test that any fix for the issue is working correctly. Please note that this will rename the class `Calculator` back to `CalculatorSoap` so all references will have to be updated.~~ **Removed**
- I don't really like the idea of testing both the server side and the client side at the same time from within Quarkus. I'm concerned that at some point one error in the extension implementation might cancel out when happening on both sides. So, I added a CXF "mini-server" that is started/stopped around the relevant tests and pretends that it is an external service. This "mini-server" does not use Quarkus or this extension. This part of the PR is not essential for the main functionality so you can remove it if you want.
- ~~Currently, none of the wrappers generated uses `JAXBElement` so that part is not being tested yet. I'm currently investigating how to get that part tested and may have something soon.~~ **Implemented**

Now also fixes #85.