### PR TITLE
fix native build without "--allow-incomplete-classpath" argument

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/cxf/deployment/QuarkusCxfProcessor.java
@@ -475,7 +475,8 @@ class QuarkusCxfProcessor {
                 new RuntimeInitializedClassBuildItem(
                         "io.netty.buffer.UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeHeapByteBuf"),
                 new RuntimeInitializedClassBuildItem("io.netty.buffer.AbstractReferenceCountedByteBuf"),
-                new RuntimeInitializedClassBuildItem("org.apache.cxf.staxutils.validation.W3CMultiSchemaFactory"));
+                new RuntimeInitializedClassBuildItem("org.apache.cxf.staxutils.validation.W3CMultiSchemaFactory"),
+                new RuntimeInitializedClassBuildItem("com.sun.xml.bind.v2.runtime.output.FastInfosetStreamWriterOutput"));
     }
 
     @BuildStep

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -142,7 +142,6 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <additionalBuildArgs>--allow-incomplete-classpath</additionalBuildArgs>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This PR removes the "--allow-incomplete-classpath" argument from the native build of the integration tests and fixes the extension so it builds without it.

I'm not a great fan of the "--allow-incomplete-classpath" option outside of debug tasks as I believe it has the potential to sweep both know and unknown issues under the rug. These issue then become visible only at runtime (after a prolongued native compilation) and usually can only be seen/fixed one at a time. In this case it is even worse as it is also forcing the users of the extension to enable that option thus causing the same problems for them.

As far as stability goes, this is basically the same code that I have used for a few months in my company's own application and it has worked solidly so far.

It should also be "neutral" in the sense that if the missing JARs are added, the normal behaviour should resume and if they're not then both JVM and native versions will fail at runtime (though the native version might fail slightly earlier).